### PR TITLE
Configurable opt-in/opt-out registry policy.

### DIFF
--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -26,7 +26,7 @@ contract Proxy is ProxyInterface {
      * @notice Uses a collision-resistant storage slot.
      */
     constructor() public {
-        Registry registry = new Registry();
+        Registry registry = new Registry(false);
         registry.transferOwnership(msg.sender);
         address registryAddress = address(registry);
         bytes32 registryAddressStorageKey = REGISTRY_ADDRESS_KEY;

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -28,24 +28,30 @@ contract Registry is RegistryInterface, Ownable {
     using HitchensUnorderedAddressSetLib for HitchensUnorderedAddressSetLib.Set;
     HitchensUnorderedAddressSetLib.Set validImplementations;
     
+    bool public OPT_IN;
+    
     address defaultImplementation;
     address constant UNDEFINED = address(0);
     bytes32 COMPONENT_UID;
     
     mapping(address => address) userImplementationChoices;
     
-    event LogNewRegistry(address sender, address registry);
+    event LogNewRegistry(address sender, address registry, bool optInPolicy);
     event LogNewImplementation(address sender, address implementation);
     event LogRecalledImplementation(address sender, address implementation);
     event LogNewDefaultImplementation(address sender, address implementation);
     event LogUserImplementation(address sender, address implementation);
     
     /**
-     * Ensures a unique identifier for the component this registry is concerned with. 
+     * @notice Ensures a unique identifier for the component this registry is concerned with. 
+     * @param optIn The permanent registry policy that governs default user upgrade policy. 
+     *        True means users accept all default implementations unless they explicitly lock in a preferred version. 
+     *        False means each user must explicitly lock in a version and default implementations have no effect.
      */
-    constructor() public {
+    constructor(bool optIn) public {
+        OPT_IN = optIn;
         COMPONENT_UID = keccak256(abi.encodePacked(msg.sender));
-        emit LogNewRegistry(msg.sender, address(this));
+        emit LogNewRegistry(msg.sender, address(this), optIn);
     }
     
     /**
@@ -98,13 +104,19 @@ contract Registry is RegistryInterface, Ownable {
     }
     
     /**
+     * @notice Returns the implementation contract to use per user choices, opt-in/opt-out registry policy and the default implementation.
      * @param user The user to inspect.
-     * @return address The user's preferred implementation address. Default if none or if the user's preferred implementation was recalled.
+     * @return address The user's effective implementation address.
      */
     function userImplementation(address user) public view returns(address) {
-        address implementation = userImplementationChoices[user];
-        if(!validImplementations.exists(implementation)) return defaultImplementation;
-        return implementation;
+        address userImpl = userImplementationChoices[user];
+        if(OPT_IN) {
+            if(!validImplementations.exists(userImpl)) return defaultImplementation;
+            return userImpl;
+        } else {
+            require(userImpl != address(0), "User must setMyImplementation() first.");
+            require(validImplementations.exists(userImpl), "User's selected implementation is recalled. User must setMyImplementation().");
+        }
     }
     
     /**

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -116,6 +116,7 @@ contract Registry is RegistryInterface, Ownable {
         } else {
             require(userImpl != address(0), "User must setMyImplementation() first.");
             require(validImplementations.exists(userImpl), "User's selected implementation is recalled. User must setMyImplementation().");
+            return userImpl;
         }
     }
     


### PR DESCRIPTION
The registry constructor takes a `bool` to set the registry policy. True for "opt-in" and false for "opt-out". An opt-out registry will force users to specify an implementation to use and lock it in until changed by them. An opt-in registry will serve up the default implementation unless the user explicitly locks in a different implementation version. 

The registry policy cannot be changed because doing so would lead to user surprise.